### PR TITLE
Slim down produced docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:18
+FROM node:18-slim
+RUN apt-get update && apt-get install -y openssl
 RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
 WORKDIR /home/node/app
 COPY package.json yarn.lock tsconfig.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:18-slim
-RUN apt-get update && apt-get install -y openssl
+RUN apt update && apt install -y openssl
 RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
 WORKDIR /home/node/app
 COPY package.json yarn.lock tsconfig.json ./

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@prisma/client": "4",
+    "@prisma/client": "^4.16.2",
     "@quixo3/prisma-session-store": "^3.1",
     "argon2": "^0.30",
     "connect-ensure-login": "^0.1",
@@ -36,7 +36,7 @@
     "prettier": "^2.8"
   },
   "scripts": {
-    "build": "npx tsc",
+    "build": "npx prisma generate && npx tsc",
     "start": "node dist/app.js",
     "dev": "npx nodemon ./app.ts",
     "format": "npx prettier **/*.ts --write",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider = "prisma-client-js"
-  binaryTargets = ["native", "debian-openssl-1.1.x"]
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,17 +66,17 @@
   resolved "https://registry.yarnpkg.com/@phc/format/-/format-1.0.0.tgz#b5627003b3216dc4362125b13f48a4daa76680e4"
   integrity sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==
 
-"@prisma/client@4":
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-4.14.1.tgz#61720f385f687f7e88de41fccade1ed62be57a54"
-  integrity sha512-TZIswkeX1ccsHG/eN2kICzg/csXll0osK3EHu1QKd8VJ3XLcXozbNELKkCNfsCUvKJAwPdDtFCzF+O+raIVldw==
+"@prisma/client@^4.16.2":
+  version "4.16.2"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-4.16.2.tgz#3bb9ebd49b35c8236b3d468d0215192267016e2b"
+  integrity sha512-qCoEyxv1ZrQ4bKy39GnylE8Zq31IRmm8bNhNbZx7bF2cU5aiCCnSa93J2imF88MBjn7J9eUQneNxUQVJdl/rPQ==
   dependencies:
-    "@prisma/engines-version" "4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c"
+    "@prisma/engines-version" "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81"
 
-"@prisma/engines-version@4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c":
-  version "4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c.tgz#0aeca447c4a5f23c83f68b8033e627b60bc01850"
-  integrity sha512-3jum8/YSudeSN0zGW5qkpz+wAN2V/NYCQ+BPjvHYDfWatLWlQkqy99toX0GysDeaUoBIJg1vaz2yKqiA3CFcQw==
+"@prisma/engines-version@4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81":
+  version "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81.tgz#d3b5dcf95b6d220e258cbf6ae19b06d30a7e9f14"
+  integrity sha512-q617EUWfRIDTriWADZ4YiWRZXCa/WuhNgLTVd+HqWLffjMSPzyM5uOWoauX91wvQClSKZU4pzI4JJLQ9Kl62Qg==
 
 "@prisma/engines@4.14.1":
   version "4.14.1"


### PR DESCRIPTION
Save the bytes! Also, make builds without cached layers faster. And images lighter to move around.

Basic stuff like:
  - using slim image
  - adding node_modules to .dockerignore

Some additional changes due to:
  - New slim debian image (bookworm) no longer bundles libssl, so it has to be installed explicitly as prisma depends on it. See: https://github.com/nodejs/docker-node/issues/1919
  - Bookworm uses different version of libssl 3.0.x rather than 1.1.x, which necessitates an update to prisma schema.
  - Prisma client itself has to be updated to support libssl 3.0.x.

Question: Should we pin the OS version to avoid such surprises in the future?
PRO: Consistent OS experience.
CON: OS version has to be bumped manually on a new release.

Resources

- Some recommendations regarding images: https://snyk.io/blog/choosing-the-best-node-js-docker-image/
- Why dockerignore: https://codefresh.io/blog/not-ignore-dockerignore-2/

New image size: 648MB
Original image size: 1.62GB